### PR TITLE
feat: Create initial web SSH client page structure

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,79 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const term = new Terminal({
+        cursorBlink: true,
+        rows: 20, // Default rows
+    });
+    // Note: FitAddon is not available directly via the global `Terminal` object when using CDN.
+    // For simplicity in this step, we'll manage resize manually or skip FitAddon for now.
+    // If FitAddon is crucial, it needs to be imported correctly, possibly requiring a build step or different CDN.
+
+    term.open(document.getElementById('terminal'));
+    // A simple way to make it fit, not as robust as FitAddon
+    function fitTerminal() {
+        const terminalContainer = document.getElementById('terminal-container');
+        // Basic fitting logic, can be improved. xterm.js's FitAddon is more sophisticated.
+        const  termDimensions = term.proposeDimensions();
+        if (termDimensions && terminalContainer.clientWidth) {
+            const cols = Math.floor(terminalContainer.clientWidth / termDimensions.cols);
+            //const rows = Math.floor(terminalContainer.clientHeight / termDimensions.rows);
+            // For now, keep rows fixed or make it configurable.
+            term.resize(cols, term.rows);
+        }
+    }
+
+    fitTerminal();
+
+
+    term.writeln('Welcome to the Web SSH Client!');
+    term.writeln('Initializing terminal...');
+    term.writeln('NOTE: Actual SSH connection requires a backend WebSocket server.');
+
+    let socket;
+
+    function connectToServer() {
+        // Replace with your WebSocket server endpoint
+        // const wsUrl = 'ws://localhost:8080/ssh';
+        // socket = new WebSocket(wsUrl);
+
+        term.writeln('Attempting to connect to WebSocket server (not implemented yet)...');
+
+        // Placeholder for actual WebSocket connection
+        // socket.onopen = () => {
+        //     term.writeln('WebSocket connection established.');
+        //     // You might want to send initial connection parameters here
+        //     // e.g., socket.send(JSON.stringify({ host: 'ubuntu@thebigone.johnny-airlines.co.uk', key: 'USER_SSH_KEY_CONTENT' }));
+        // };
+
+        // socket.onmessage = (event) => {
+        //     // Data received from server (SSH output)
+        //     term.write(typeof event.data === 'string' ? event.data : new Uint8Array(event.data));
+        // };
+
+        // socket.onerror = (error) => {
+        //     term.writeln(`WebSocket error: ${error.message}`);
+        // };
+
+        // socket.onclose = () => {
+        //     term.writeln('WebSocket connection closed.');
+        // };
+    }
+
+    // Call this function when the user wants to connect (e.g., after providing an SSH key)
+    // connectToServer();
+
+
+    term.onData(data => {
+        // If WebSocket is connected, send data to server
+        // if (socket && socket.readyState === WebSocket.OPEN) {
+        //     socket.send(data);
+        // } else {
+            // For now, just echo it back locally
+            term.write(data);
+            term.writeln('\n[No backend connected. Echoing locally.]');
+        // }
+    });
+
+    window.addEventListener('resize', () => {
+        fitTerminal();
+    });
+});

--- a/ssh_client.html
+++ b/ssh_client.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Web SSH Client</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css" />
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Web SSH Client</h1>
+
+    <div>
+        <label for="server-address">Server Address:</label>
+        <input type="text" id="server-address" value="ubuntu@thebigone.johnny-airlines.co.uk" readonly>
+    </div>
+
+    <div>
+        <label for="ssh-key">SSH Key:</label>
+        <input type="file" id="ssh-key-input" accept=".pem,.key">
+        <small><em>Placeholder for SSH key input</em></small>
+    </div>
+
+    <div id="terminal-container">
+        <div id="terminal"></div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,59 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+h1 {
+    color: #333;
+    text-align: center;
+}
+
+div {
+    margin-bottom: 15px;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+
+input[type="text"],
+input[type="file"] {
+    width: calc(100% - 22px); /* Adjust for padding and border */
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+input[type="text"][readonly] {
+    background-color: #eee;
+}
+
+small {
+    display: block;
+    margin-top: 5px;
+    font-style: italic;
+    color: #666;
+}
+
+#terminal-container {
+    border: 1px solid #ccc;
+    padding: 10px;
+    background-color: #000; /* Typically terminals have a dark background */
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+/* Styling for xterm.js can be further customized if needed,
+   but its default theme is generally good.
+   The xterm.js CSS linked in the HTML handles the core terminal look.
+   This is just for the container. */
+.xterm {
+    /* Example: if you need to override xterm's default font that isn't fitting well */
+    /* font-family: 'Courier New', Courier, monospace; */
+    /* font-size: 14px; */
+}


### PR DESCRIPTION
Creates an HTML page with xterm.js for terminal emulation. Includes placeholders for SSH key input and the target server address 'ubuntu@thebigone.johnny-airlines.co.uk'.

Note: This is the frontend component only. A backend WebSocket server is required to handle the actual SSH connection.